### PR TITLE
Fix security issue (admin ID visible in page source).

### DIFF
--- a/comment.form.php
+++ b/comment.form.php
@@ -1,7 +1,7 @@
 <div class="center-box">
 	<form action="comment.new.php" method="post" class="form">
 	<input type="hidden" name="pollId" value="<?php echo $poll->getId() ?>"/>
-	<input type="hidden" name="pollAdminId" value="<?php echo $poll->getAdminId() ?>"/>
+	<input type="hidden" name="pollAdminId" value="<?php echo $adminId ?>"/>
 		<ul class="form">
 		    <li>
 		        <label><?php echo SPR_COMMENT_NAME ?> <span class="required">*</span></label>

--- a/poll.js.php
+++ b/poll.js.php
@@ -45,7 +45,7 @@
         // delete poll button functionality
         $("#ctrl-delete-poll").click(function(){
             if (confirm("<?php echo SPR_DELETE_POLL_CONFIRM ?>")){
-                $.post( "poll.delete.php", { pollId: "<?php echo $poll->getId() ?>", adm: "<?php echo $poll->getAdminId() ?>" } ).done( function() {
+                $.post( "poll.delete.php", { pollId: $(this).attr("data-poll"), adm: $(this).attr("data-adminid") } ).done( function() {
                     location.href = "index.php";
                 });
             }

--- a/poll.view.php
+++ b/poll.view.php
@@ -11,7 +11,7 @@
 		</button>
 		<!-- DELETE POLL BUTTON -->
 		<?php if (strcmp($poll->getAdminId(), $adminId) == 0) { ?>
-			<button id="ctrl-delete-poll" type="button">
+			<button id="ctrl-delete-poll" type="button" data-poll="<?php echo $poll->getId() ?>" data-adminid="<?php echo $adminId ?>">
 				<?php echo SPR_POLL_CONTROL_DELETE ?>
 			</button>
 		<?php } ?>


### PR DESCRIPTION
Even if "Admin Link" option was checked during poll creation, the admin ID could be easily found in page source code.
Additionally after writing a comment, one was automatically forwarded to the poll admin page!